### PR TITLE
Support for async requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,5 @@ content_response = client.content(
 print(content_response)
 ```
 
-See the `examples/` directory for more examples and documentation.
+See the `examples/` directory for more examples and documentation, for instance on how to use Linkup
+entrypoints using asynchronous functions.

--- a/examples/5_asynchronous_search.py
+++ b/examples/5_asynchronous_search.py
@@ -1,0 +1,41 @@
+"""
+All Linkup entrypoints come with an asynchronous version. This snippet demonstrates how to run
+multiple asynchronous searches concurrently, which decreases by a lot the total computation
+duration.
+"""
+
+import asyncio
+import time
+
+from linkup import LinkupClient
+
+client = LinkupClient()
+
+queries: list[str] = [
+    "What are the 3 major events in the life of Abraham Lincoln?",
+    "What are the 3 major events in the life of George Washington?",
+]
+
+t0: float = time.time()
+
+
+async def search(idx: int, query: str) -> None:
+    """Run an asynchronous search and display its results and the duration from the beginning."""
+    response = await client.async_search(
+        query=query,
+        depth="standard",  # or "deep"
+        output_type="searchResults",  # or "sourcedAnswer" or "structured"
+    )
+    print(f"{idx+1}: {time.time() - t0:.3f}s")
+    print(response)
+    print("-" * 100)
+
+
+async def main() -> None:
+    """Run multiple asynchronous searches concurrently."""
+    coroutines = [search(idx=idx, query=query) for idx, query in enumerate(queries)]
+    await asyncio.gather(*coroutines)
+    print(f"Total time: {time.time() - t0:.3f}s")
+
+
+asyncio.run(main())

--- a/linkup/client.py
+++ b/linkup/client.py
@@ -24,7 +24,6 @@ class LinkupClient:
             raise ValueError("The Linkup API key was not provided")
 
         self.api_key = api_key
-        self.client = httpx.Client(base_url=self.__base_url__, headers=self._headers())
 
     def _user_agent(self) -> str:
         return f"Linkup-Python/{self.__version__}"
@@ -36,11 +35,12 @@ class LinkupClient:
         }
 
     def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
-        return self.client.request(
-            method=method,
-            url=url,
-            **kwargs,
-        )
+        with httpx.Client(base_url=self.__base_url__, headers=self._headers()) as client:
+            return client.request(
+                method=method,
+                url=url,
+                **kwargs,
+            )
 
     def content(self, url: str) -> LinkupContent:
         """

--- a/linkup/client.py
+++ b/linkup/client.py
@@ -42,6 +42,37 @@ class LinkupClient:
                 **kwargs,
             )
 
+    async def _async_request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        async with httpx.AsyncClient(base_url=self.__base_url__, headers=self._headers()) as client:
+            return await client.request(
+                method=method,
+                url=url,
+                **kwargs,
+            )
+
+    def _raise_content_error(self, response: httpx.Response) -> None:
+        message: Any = response.json().get("message", "No message provided")
+        message = ", ".join(message) if isinstance(message, list) else str(message)
+
+        if response.status_code == 400:
+            raise LinkupInvalidRequestError(
+                "The Linkup API returned an invalid request error (400). Make sure the URL you "
+                "requested is a valid URL in our Premium Sources Partners, and you are using "
+                "the latest version of the Python SDK.\n"
+                f"Original error message: {message}."
+            )
+        elif response.status_code == 403:
+            raise LinkupAuthenticationError(
+                "The Linkup API returned an authentication error (403). Make sure your API "
+                "key is valid, and you haven't exhausted your credits.\n"
+                f"Original error message: {message}."
+            )
+        else:
+            raise LinkupUnknownError(
+                f"The Linkup API returned an unknown error ({response.status_code}).\n"
+                f"Original error message: ({message})."
+            )
+
     def content(self, url: str) -> LinkupContent:
         """
         Retrieve the content of a webpage of one of our Premium Sources Partners.
@@ -67,29 +98,117 @@ class LinkupClient:
             timeout=None,
         )
         if response.status_code != 200:
-            message: Any = response.json().get("message", "No message provided")
-            message = ", ".join(message) if isinstance(message, list) else str(message)
-            if response.status_code == 400:
-                raise LinkupInvalidRequestError(
-                    "The Linkup API returned an invalid request error (400). Make sure the URL you "
-                    "requested is a valid URL in our Premium Sources Partners, and you are using "
-                    "the latest version of the Python SDK.\n"
-                    f"Original error message: {message}."
-                )
-            elif response.status_code == 403:
-                raise LinkupAuthenticationError(
-                    "The Linkup API returned an authentication error (403). Make sure your API "
-                    "key is valid, and you haven't exhausted your credits.\n"
-                    f"Original error message: {message}."
-                )
-            else:
-                raise LinkupUnknownError(
-                    f"The Linkup API returned an unknown error ({response.status_code}).\n"
-                    f"Original error message: ({message})."
+            self._raise_content_error(response=response)
+
+        return LinkupContent.model_validate(response.json())
+
+    async def async_content(self, url: str) -> LinkupContent:
+        """
+        Asynchronously retrieve the content of a webpage of one of our Premium Sources Partners.
+
+        Args:
+            url: The URL of the webpage.
+
+        Returns:
+            The content of the webpage.
+
+        Raises:
+            LinkupInvalidRequestError: If the URL is not a valid URL in our Premium Sources
+                Partners.
+            LinkupAuthenticationError: If the Linkup API key is invalid, or there is no more credit
+                available.
+        """
+        params: dict[str, str] = dict(url=url)
+
+        response: httpx.Response = await self._async_request(
+            method="GET",
+            url="/content",
+            params=params,
+            timeout=None,
+        )
+        if response.status_code != 200:
+            self._raise_content_error(response)
+
+        return LinkupContent.model_validate(response.json())
+
+    def _get_search_params(
+        self,
+        query: str,
+        depth: Literal["standard", "deep"],
+        output_type: Literal["searchResults", "sourcedAnswer", "structured"],
+        structured_output_schema: Type[BaseModel] | str | None,
+    ) -> dict[str, str]:
+        params: dict[str, str] = dict(
+            q=query,
+            depth=depth,
+            outputType=output_type,
+        )
+
+        if output_type == "structured":
+            if structured_output_schema is None:
+                raise ValueError(
+                    "A structured_output_schema must be provided when using "
+                    "output_type='structured'"
                 )
 
+            if isinstance(structured_output_schema, str):
+                params["structuredOutputSchema"] = structured_output_schema
+            elif issubclass(structured_output_schema, BaseModel):
+                json_schema: dict[str, Any] = structured_output_schema.model_json_schema()
+                params["structuredOutputSchema"] = json.dumps(json_schema)
+            else:
+                raise TypeError(
+                    f"Unexpected structured_output_schema type: '{type(structured_output_schema)}'"
+                )
+
+        return params
+
+    def _raise_search_error(self, response: httpx.Response) -> None:
+        message: Any = response.json().get("message", "No message provided")
+        message = ", ".join(message) if isinstance(message, list) else str(message)
+
+        if response.status_code == 400:
+            raise LinkupInvalidRequestError(
+                "The Linkup API returned an invalid request error (400). Make sure the "
+                "parameters you are using are valid, (e.g. structured_output_schema must be a "
+                "valid object schema if output_type is 'structured'), and you are using the "
+                "latest version of the Python SDK.\n"
+                f"Original error message: {message}."
+            )
+        elif response.status_code == 403:
+            raise LinkupAuthenticationError(
+                "The Linkup API returned an authentication error (403). Make sure your API "
+                "key is valid, and you haven't exhausted your credits.\n"
+                f"Original error message: {message}."
+            )
+        else:
+            raise LinkupUnknownError(
+                f"The Linkup API returned an unknown error ({response.status_code}).\n"
+                f"Original error message: ({message})."
+            )
+
+    def _validate_search_response(
+        self,
+        response: httpx.Response,
+        output_type: Literal["searchResults", "sourcedAnswer", "structured"],
+        structured_output_schema: Type[BaseModel] | str | None,
+    ) -> Any:
         response_data: Any = response.json()
-        return LinkupContent.model_validate(response_data)
+        output_base_model: Type[BaseModel] | None = None
+        if output_type == "searchResults":
+            output_base_model = LinkupSearchResults
+        elif output_type == "sourcedAnswer":
+            output_base_model = LinkupSourcedAnswer
+        elif (
+            output_type == "structured"
+            and not isinstance(structured_output_schema, (str, type(None)))
+            and issubclass(structured_output_schema, BaseModel)
+        ):
+            output_base_model = structured_output_schema
+
+        if output_base_model is None:
+            return response_data
+        return output_base_model.model_validate(response_data)
 
     def search(
         self,
@@ -131,28 +250,12 @@ class LinkupClient:
             LinkupAuthenticationError: If the Linkup API key is invalid, or there is no more credit
                 available.
         """
-        params: dict[str, str] = dict(
-            q=query,
+        params: dict[str, str] = self._get_search_params(
+            query=query,
             depth=depth,
-            outputType=output_type,
+            output_type=output_type,
+            structured_output_schema=structured_output_schema,
         )
-
-        if output_type == "structured":
-            if structured_output_schema is None:
-                raise ValueError(
-                    "A structured_output_schema must be provided when using "
-                    "output_type='structured'"
-                )
-
-            if isinstance(structured_output_schema, str):
-                params["structuredOutputSchema"] = structured_output_schema
-            elif issubclass(structured_output_schema, BaseModel):
-                json_schema: dict[str, Any] = structured_output_schema.model_json_schema()
-                params["structuredOutputSchema"] = json.dumps(json_schema)
-            else:
-                raise TypeError(
-                    f"Unexpected structured_output_schema type: '{type(structured_output_schema)}'"
-                )
 
         response: httpx.Response = self._request(
             method="GET",
@@ -161,41 +264,72 @@ class LinkupClient:
             timeout=None,
         )
         if response.status_code != 200:
-            message: Any = response.json().get("message", "No message provided")
-            message = ", ".join(message) if isinstance(message, list) else str(message)
-            if response.status_code == 400:
-                raise LinkupInvalidRequestError(
-                    "The Linkup API returned an invalid request error (400). Make sure the "
-                    "parameters you are using are valid, (e.g. structured_output_schema must be a "
-                    "valid object schema if output_type is 'structured'), and you are using the "
-                    "latest version of the Python SDK.\n"
-                    f"Original error message: {message}."
-                )
-            elif response.status_code == 403:
-                raise LinkupAuthenticationError(
-                    "The Linkup API returned an authentication error (403). Make sure your API "
-                    "key is valid, and you haven't exhausted your credits.\n"
-                    f"Original error message: {message}."
-                )
-            else:
-                raise LinkupUnknownError(
-                    f"The Linkup API returned an unknown error ({response.status_code}).\n"
-                    f"Original error message: ({message})."
-                )
+            self._raise_search_error(response)
 
-        response_data: Any = response.json()
-        output_base_model: Type[BaseModel] | None = None
-        if output_type == "searchResults":
-            output_base_model = LinkupSearchResults
-        elif output_type == "sourcedAnswer":
-            output_base_model = LinkupSourcedAnswer
-        elif (
-            output_type == "structured"
-            and not isinstance(structured_output_schema, (str, type(None)))
-            and issubclass(structured_output_schema, BaseModel)
-        ):
-            output_base_model = structured_output_schema
+        return self._validate_search_response(
+            response=response,
+            output_type=output_type,
+            structured_output_schema=structured_output_schema,
+        )
 
-        if output_base_model is None:
-            return response_data
-        return output_base_model.model_validate(response_data)
+    async def async_search(
+        self,
+        query: str,
+        depth: Literal["standard", "deep"] = "standard",
+        output_type: Literal["searchResults", "sourcedAnswer", "structured"] = "searchResults",
+        structured_output_schema: Type[BaseModel] | str | None = None,
+    ) -> Any:
+        """
+        Asynchronously search for a query in the Linkup API.
+
+        Args:
+            query: The search query.
+            depth: The depth of the search, "standard" (default) or "deep". Asking for a standard
+                depth will make the API respond quickly. In contrast, asking for a deep depth will
+                take longer for the API to respond, but results will be spot on.
+            output_type: The type of output which is expected: "searchResults" (default) will output
+                raw search results, "sourcedAnswer" will output the answer to the query and sources
+                supporting it, and "structured" will base the output on the format provided in
+                structured_output_schema.
+            structured_output_schema: If output_type is "structured", specify the schema of the
+                output. Supported formats are a pydantic.BaseModel or a string representing a
+                valid object JSON schema.
+
+        Returns:
+            The Linkup API search result. If output_type is "searchResults", the result will be a
+            linkup.LinkupSearchResults. If output_type is "sourcedAnswer", the result will be a
+            linkup.LinkupSourcedAnswer. If output_type is "structured", the result will be either an
+            instance of the provided pydantic.BaseModel, or an arbitrary data structure, following
+            structured_output_schema.
+
+        Raises:
+            ValueError: If structured_output_schema is not provided when output_type is
+                "structured".
+            TypeError: If structured_output_schema is not a string or a pydantic.BaseModel when
+                output_type is "structured".
+            LinkupInvalidRequestError: If structured_output_schema doesn't represent a valid object
+                JSON schema when output_type is "structured".
+            LinkupAuthenticationError: If the Linkup API key is invalid, or there is no more credit
+                available.
+        """
+        params: dict[str, str] = self._get_search_params(
+            query=query,
+            depth=depth,
+            output_type=output_type,
+            structured_output_schema=structured_output_schema,
+        )
+
+        response: httpx.Response = await self._async_request(
+            method="GET",
+            url="/search",
+            params=params,
+            timeout=None,
+        )
+        if response.status_code != 200:
+            self._raise_search_error(response)
+
+        return self._validate_search_response(
+            response=response,
+            output_type=output_type,
+            structured_output_schema=structured_output_schema,
+        )


### PR DESCRIPTION
This PR does mainly 4 things:
- make sure we close the request client after each request, to avoid keeping connections opened
- introduce intermediate functions (`_get_..._params`, `_raise_..._error`) to be able to re-use their code and decrease code copy/pastes
- add the async version of content & search
- add an example in the documentation for using the async search entrypoint