### PR TITLE
fix: mark package as typed

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-mock
+setuptools
 types-setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-httpx
-pydantic

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     ],
     keywords="linkup api sdk client search",
     packages=find_packages(),
+    package_data={"linkup": ["py.typed"]},
     python_requires=">=3.8",
     install_requires=[
         "httpx",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="linkup-sdk",
-    version="0.1.6",
+    version="0.1.7",
     author="LINKUP TECHNOLOGIES",
     author_email="contact@linkup.so",
     description="A Python Client SDK for the Linkup API",


### PR DESCRIPTION
## Description

This does a few minor fixes, the most important one being that the package is now marked as typed, which makes that mypy, when used in a package where the linkup SDK is installed, will use the type annotations in the code instead of raising an error.
