### PR TITLE
[DO NOT MERGE - but can still review] Add InsufficientCredit and NoResult errors

### DIFF
--- a/linkup/__init__.py
+++ b/linkup/__init__.py
@@ -3,7 +3,9 @@ from .client import (
 )
 from .errors import (
     LinkupAuthenticationError,
+    LinkupInsufficientCreditError,
     LinkupInvalidRequestError,
+    LinkupNoResultError,
     LinkupUnknownError,
 )
 from .types import (
@@ -19,6 +21,8 @@ __all__ = [
     "LinkupAuthenticationError",
     "LinkupInvalidRequestError",
     "LinkupUnknownError",
+    "LinkupNoResultError",
+    "LinkupInsufficientCreditError",
     "LinkupContent",
     "LinkupSearchResult",
     "LinkupSearchResults",

--- a/linkup/client.py
+++ b/linkup/client.py
@@ -125,8 +125,9 @@ class LinkupClient:
                 pydantic.BaseModel when output_type is "structured".
             LinkupInvalidRequestError: If structured_output_schema doesn't represent a valid object
                 JSON schema when output_type is "structured".
-            LinkupAuthenticationError: If the Linkup API key is invalid, or there is no more credit
-                available.
+            LinkupAuthenticationError: If the Linkup API key is invalid.
+            LinkupInsufficientCreditError: If you have run out of credit.
+            LinkupNoResultError: If the search query did not yield any result.
         """
         params: Dict[str, str] = self._get_search_params(
             query=query,

--- a/linkup/errors.py
+++ b/linkup/errors.py
@@ -2,7 +2,16 @@ class LinkupInvalidRequestError(Exception):
     """Invalid request error, raised when the Linkup API returns a 400 status code.
 
     It is returned by the Linkup API when the request is invalid, typically when a mandatory
-    parameter is missing, or isn't valid (type, structure, etc.)
+    parameter is missing, or isn't valid (type, structure, etc.).
+    """
+
+    pass
+
+
+class LinkupNoResultError(Exception):
+    """No result error, raised when the Linkup API returns a 400 status code.
+
+    It is returned by the Linkup API when the search query did not yield any result.
     """
 
     pass
@@ -13,6 +22,15 @@ class LinkupAuthenticationError(Exception):
 
     It is returned when there is an authenfication issue, typically when the API key is not valid
     or when the user has exhausted its credits.
+    """
+
+    pass
+
+
+class LinkupInsufficientCreditError(Exception):
+    """Insufficient credit error, raised when the Linkup API returns a 429 status code.
+
+    It is returned when you have run out of credits.
     """
 
     pass

--- a/linkup/errors.py
+++ b/linkup/errors.py
@@ -20,8 +20,7 @@ class LinkupNoResultError(Exception):
 class LinkupAuthenticationError(Exception):
     """Authenfication error, raised when the Linkup API returns a 403 status code.
 
-    It is returned when there is an authenfication issue, typically when the API key is not valid
-    or when the user has exhausted its credits.
+    It is returned when there is an authenfication issue, typically when the API key is not valid.
     """
 
     pass


### PR DESCRIPTION
This PR adds support for the upcoming API errors 
- 400 NoResult -> happens on the search endpoint instead of getting a 200 with empty string
- 429 InsufficientCredit -> self explanatory

I also added the possibility to override the API base URL so we can use this package locally hitting localhost and later on once we have a staging env.