### PR TITLE
chore!: drop Python 3.8 support and other fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"] # Only test min and max stable versions
+        python-version: ["3.9", "3.13"] # Only test min and max supported versions
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/linkup/client.py
+++ b/linkup/client.py
@@ -20,7 +20,7 @@ class LinkupClient:
     The Linkup Client class.
     """
 
-    __version__ = "0.1.8"
+    __version__ = "0.2.0"
 
     def __init__(
         self, api_key: Optional[str] = None, base_url: str = "https://api.linkup.so/v1"

--- a/linkup/client.py
+++ b/linkup/client.py
@@ -20,7 +20,7 @@ class LinkupClient:
     The Linkup Client class.
     """
 
-    __version__ = "0.1.0"
+    __version__ = "0.1.8"
 
     def __init__(
         self, api_key: Optional[str] = None, base_url: str = "https://api.linkup.so/v1"

--- a/linkup/client.py
+++ b/linkup/client.py
@@ -293,13 +293,7 @@ class LinkupClient:
             outputType=output_type,
         )
 
-        if output_type == "structured":
-            if structured_output_schema is None:
-                raise TypeError(
-                    "A structured_output_schema must be provided when using "
-                    "output_type='structured'"
-                )
-
+        if output_type == "structured" and structured_output_schema is not None:
             if isinstance(structured_output_schema, str):
                 params["structuredOutputSchema"] = structured_output_schema
             elif issubclass(structured_output_schema, BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude_also = ["raise ValueError", "raise TypeError"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = [

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="linkup-sdk",
-    version="0.1.8",
+    version="0.2.0",
     author="LINKUP TECHNOLOGIES",
     author_email="contact@linkup.so",
     description="A Python Client SDK for the Linkup API",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     keywords="linkup api sdk client search",
     packages=find_packages(),
     package_data={"linkup": ["py.typed"]},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "httpx",
         "pydantic",


### PR DESCRIPTION
## Description

This PR does a few different small things:
- drop the support of Python 3.8 and test in 3.13
- fix the client version that never got updated
- remove an error handled in the SDK, to leave the error management to the API
- prepare the 0.2.0 release