### PR TITLE
fix: install uv in python-semantic-release action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
   "pydantic"
 ]
 
+[project.optional-dependencies]
+build = ["uv>=0.8.0,<0.9.0"] # For python-semantic-release build command, used in GitHub actions
+
 [project.urls]
 Homepage = "https://github.com/LinkupPlatform/linkup-python-sdk"
 Documentation = "https://github.com/LinkupPlatform/linkup-python-sdk#readme"
@@ -84,6 +87,7 @@ commit_parser = "conventional"
 allow_zero_version = true
 major_on_zero = false
 build_command = """
+    python -m pip install -e '.[build]'
     uv lock --upgrade-package "$PACKAGE_NAME"
     git add uv.lock
     uv build


### PR DESCRIPTION
## Description

<!-- Describe the changes you made in this PR. -->
This should fix an issue with the python-semantic-release workflow.

## Checklist

<!-- Make sure all items below are checked before submitting the PR. -->

- [x] I have run the tests locally with `make install-dev` and `make test`
- [x] I have updated the `README.md` if my changes affected it
- [x] I have updated the package version in `linkup/_version.py` and `pyproject.toml` if I plan on creating a new release
