### PR TITLE
refactor: streamline tests and add more

### DIFF
--- a/src/linkup/client.py
+++ b/src/linkup/client.py
@@ -312,38 +312,34 @@ class LinkupClient:
         output_type: Literal["searchResults", "sourcedAnswer", "structured"],
         structured_output_schema: Union[type[BaseModel], str, None],
         include_images: bool,
-        from_date: Union[date, None],
-        include_domains: Union[list[str], None],
         exclude_domains: Union[list[str], None],
+        include_domains: Union[list[str], None],
+        from_date: Union[date, None],
         to_date: Union[date, None],
     ) -> dict[str, Union[str, bool, list[str]]]:
-        params: dict[str, Union[str, bool, list[str]]] = dict(
-            q=query,
-            depth=depth,
-            outputType=output_type,
-            includeImages=include_images,
-        )
-
-        if output_type == "structured" and structured_output_schema is not None:
+        structured_output_schema_param: str = ""
+        if structured_output_schema is not None:
             if isinstance(structured_output_schema, str):
-                params["structuredOutputSchema"] = structured_output_schema
+                structured_output_schema_param = structured_output_schema
             elif issubclass(structured_output_schema, BaseModel):
                 json_schema: dict[str, Any] = structured_output_schema.model_json_schema()
-                params["structuredOutputSchema"] = json.dumps(json_schema)
+                structured_output_schema_param = json.dumps(json_schema)
             else:
                 raise TypeError(
                     f"Unexpected structured_output_schema type: '{type(structured_output_schema)}'"
                 )
-        if from_date is not None:
-            params["fromDate"] = from_date.isoformat()
-        if exclude_domains is not None:
-            params["excludeDomains"] = exclude_domains
-        if include_domains is not None:
-            params["includeDomains"] = include_domains
-        if to_date is not None:
-            params["toDate"] = to_date.isoformat()
 
-        return params
+        return dict(
+            q=query,
+            depth=depth,
+            outputType=output_type,
+            structuredOutputSchema=structured_output_schema_param,
+            includeImages=include_images,
+            excludeDomains=exclude_domains or [],
+            includeDomains=include_domains or [],
+            fromDate=from_date.isoformat() if from_date is not None else "",
+            toDate=to_date.isoformat() if to_date is not None else "",
+        )
 
     def _validate_search_response(
         self,


### PR DESCRIPTION
## Description

<!-- Describe the changes you made in this Pull Request. -->
This PR refactors the tests to leverage the `pytest.mark.parameterize` syntax and removes most of the duplicate in the test files. This made me able to test a bit more (some more usecases, and more tests, like the check of the data sent to the request) while also reducing the number of test lines by half.

Doing so I realized a lack of systematization in the way we handle default parameters: sometimes they were not sent to the API at all, sometimes with the SDK default value. If SDK & API defaults are the same, this doesn't change a thing, but otherwise it might create surprises, so I made sure the default SDK parameters are always passed.

## Checklist

<!-- Make sure all items below are checked before submitting the Pull Request. -->

- [x] I have installed pre-commit on this project (for instance with the `make install-dev` command)
  **before** creating any commit, or I have run successfully the `make lint` command on my changes
- [x] I have run successfully the `make test` command on my changes
- [x] I have updated the `README.md` if my changes affected it
