### PR TITLE
feat(client): add custom auth header name support

### DIFF
--- a/src/linkup/_client.py
+++ b/src/linkup/_client.py
@@ -59,6 +59,10 @@ class LinkupClient:
         x402_signer: An optional x402 signer for payment-gated endpoints. If provided, the
             client will attempt to handle 402 responses automatically. Cannot be used together
             with api_key.
+        auth_header: Custom header name to use for the API key (e.g.
+            ``"Ocp-Apim-Subscription-Key"``). When set, the API key value is sent as
+            ``<auth_header>: <api_key>`` instead of the default
+            ``Authorization: Bearer <api_key>``.
 
     Raises:
         ValueError: If the API key is not provided and not found in the environment variable.
@@ -72,6 +76,7 @@ class LinkupClient:
         api_key: str | SecretStr | None = None,
         base_url: str = "https://api.linkup.so/v1",
         x402_signer: LinkupX402Signer | None = None,
+        auth_header: str | None = None,
     ) -> None:
         if api_key is not None and x402_signer is not None:
             raise ValueError("Cannot provide both api_key and x402_signer")
@@ -90,6 +95,7 @@ class LinkupClient:
             self._api_key = api_key
 
         self._base_url: str = base_url
+        self._auth_header: str | None = auth_header
 
     def search(
         self,
@@ -889,7 +895,10 @@ class LinkupClient:
     def _headers(self) -> dict[str, str]:  # pragma: no cover
         headers: dict[str, str] = {"User-Agent": self._user_agent()}
         if self._api_key is not None:
-            headers["Authorization"] = f"Bearer {self._api_key.get_secret_value()}"
+            if self._auth_header is not None:
+                headers[self._auth_header] = self._api_key.get_secret_value()
+            else:
+                headers["Authorization"] = f"Bearer {self._api_key.get_secret_value()}"
         return headers
 
     def _request(

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1409,7 +1409,6 @@ def test_client_custom_auth_header(
     mocker: MockerFixture,
 ) -> None:
     client = linkup.Client(api_key="my-key", auth_header="Ocp-Apim-Subscription-Key")
-    assert client._auth_header == "Ocp-Apim-Subscription-Key"  # noqa: SLF001
 
     client_mock = mocker.patch("httpx.Client")
     client_mock.return_value.__enter__.return_value = client_mock.return_value

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1405,6 +1405,26 @@ def test_client_both_api_key_and_x402_signer_raises(
         linkup.Client(api_key="test-key", x402_signer=mock_x402_signer)
 
 
+def test_client_custom_auth_header(
+    mocker: MockerFixture,
+) -> None:
+    client = linkup.Client(api_key="my-key", auth_header="Ocp-Apim-Subscription-Key")
+    assert client._auth_header == "Ocp-Apim-Subscription-Key"  # noqa: SLF001
+
+    client_mock = mocker.patch("httpx.Client")
+    client_mock.return_value.__enter__ = lambda s: s
+    client_mock.return_value.__exit__ = MagicMock(return_value=False)
+    client_mock.return_value.request.return_value = Response(
+        status_code=200, content=b'{"results": []}'
+    )
+    client.search(query="query", depth="standard", output_type="searchResults")
+
+    init_kwargs = client_mock.call_args[1]
+    assert "Ocp-Apim-Subscription-Key" in init_kwargs["headers"]
+    assert init_kwargs["headers"]["Ocp-Apim-Subscription-Key"] == "my-key"
+    assert "Authorization" not in init_kwargs["headers"]
+
+
 def test_client_x402_no_auth_header(
     mocker: MockerFixture,
     x402_client: linkup.Client,

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1412,8 +1412,7 @@ def test_client_custom_auth_header(
     assert client._auth_header == "Ocp-Apim-Subscription-Key"  # noqa: SLF001
 
     client_mock = mocker.patch("httpx.Client")
-    client_mock.return_value.__enter__ = lambda s: s
-    client_mock.return_value.__exit__ = MagicMock(return_value=False)
+    client_mock.return_value.__enter__.return_value = client_mock.return_value
     client_mock.return_value.request.return_value = Response(
         status_code=200, content=b'{"results": []}'
     )


### PR DESCRIPTION
## Description

<!-- Describe the changes you made in this Pull Request. -->

Some API gateways (e.g. Azure APIM) require the key in a
non-standard header like `Ocp-Apim-Subscription-Key` instead of
`Authorization: Bearer`. `auth_header` lets callers override the
header name; the key value is sent as-is when set.

## Checklist

<!-- Make sure all items below are checked before submitting the Pull Request. -->

- [x] I have installed `prek` on this project (for instance with the `make install-dev` command)
  **before** creating any commit, or I have run successfully the `make lint` command on my changes.
- [x] I have run successfully the `make typecheck test` command on my changes.
- [x] I have updated the `README.md` if my changes affected it.
