### PR TITLE
fix: validate research structured input before request

### DIFF
--- a/src/linkup/_client.py
+++ b/src/linkup/_client.py
@@ -535,11 +535,13 @@ class LinkupClient:
             The newly created research task, with "pending" status and no output.
 
         Raises:
-            TypeError: If structured_output_schema is not a string, dictionary, or
-                pydantic.BaseModel when provided.
+            TypeError: If structured_output_schema is not provided when output_type is
+                "structured", or if it is not a string, dictionary, or pydantic.BaseModel when
+                provided.
             LinkupInvalidRequestError: If the request parameters are invalid.
             LinkupAuthenticationError: If the Linkup API key is invalid.
             LinkupInsufficientCreditError: If you have run out of credit.
+            LinkupBudgetLimitExceededError: If the API key has reached its configured budget limit.
             LinkupTimeoutError: If the request times out.
         """
         params = self._get_research_params(
@@ -606,11 +608,13 @@ class LinkupClient:
             The newly created research task, with "pending" status and no output.
 
         Raises:
-            TypeError: If structured_output_schema is not a string, dictionary, or
-                pydantic.BaseModel when provided.
+            TypeError: If structured_output_schema is not provided when output_type is
+                "structured", or if it is not a string, dictionary, or pydantic.BaseModel when
+                provided.
             LinkupInvalidRequestError: If the request parameters are invalid.
             LinkupAuthenticationError: If the Linkup API key is invalid.
             LinkupInsufficientCreditError: If you have run out of credit.
+            LinkupBudgetLimitExceededError: If the API key has reached its configured budget limit.
             LinkupTimeoutError: If the request times out.
         """
         params = self._get_research_params(
@@ -1459,6 +1463,11 @@ class LinkupClient:
         exclude_domains: list[str] | None,
         include_domains: list[str] | None,
     ) -> dict[str, str | bool | list[str]]:
+        if output_type == "structured" and structured_output_schema is None:
+            raise TypeError(
+                "structured_output_schema must be provided when output_type is 'structured'"
+            )
+
         params: dict[str, str | bool | list[str]] = {
             "q": query,
             "outputType": output_type,

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -718,6 +718,17 @@ def test_research(mocker: MockerFixture, client: linkup.Client) -> None:
     )
 
 
+def test_research_structured_output_requires_schema(client: linkup.Client) -> None:
+    with pytest.raises(
+        TypeError,
+        match="structured_output_schema must be provided",
+    ):
+        client.research(
+            query="query",
+            output_type="structured",
+        )
+
+
 def test_get_research_structured_output_keeps_sourced_answer_shape_raw(
     mocker: MockerFixture, client: linkup.Client
 ) -> None:
@@ -802,6 +813,20 @@ async def test_async_research(mocker: MockerFixture, client: linkup.Client) -> N
     assert research_response.output == {"summary": "done"}
     assert research_response.input.query == "query"
     assert research_response.input.structured_output_schema == {"type": "object"}
+
+
+@pytest.mark.asyncio
+async def test_async_research_structured_output_requires_schema(
+    client: linkup.Client,
+) -> None:
+    with pytest.raises(
+        TypeError,
+        match="structured_output_schema must be provided",
+    ):
+        await client.async_research(
+            query="query",
+            output_type="structured",
+        )
 
 
 def test_research_with_iso_datetime_string_dates(


### PR DESCRIPTION
## Description

- add the missing client-side validation that requires structured_output_schema when calling research(..., output_type=structured)
- keep sync and async research behavior aligned with the platform DTO contract and the existing search validation path
- add unit tests for the sync and async research validation cases

## Checklist

- [x] I have run make lint on my changes.
- [x] I have run make typecheck test on my changes.
- [ ] I have updated README.md if my changes affected it.