### PR TITLE
fix: handle unsupported task types in task endpoints

### DIFF
--- a/src/linkup/__init__.py
+++ b/src/linkup/__init__.py
@@ -15,6 +15,7 @@ from ._errors import (
     LinkupTimeoutError,
     LinkupTooManyRequestsError,
     LinkupUnknownError,
+    LinkupUnsupportedTaskTypeError,
 )
 from ._types import (
     JSONObject,
@@ -78,6 +79,7 @@ TasksQueueLimitExceededError = LinkupTasksQueueLimitExceededError
 TimeoutError = LinkupTimeoutError  # noqa: A001
 TooManyRequestsError = LinkupTooManyRequestsError
 UnknownError = LinkupUnknownError
+UnsupportedTaskTypeError = LinkupUnsupportedTaskTypeError
 
 __all__ = [
     "AuthenticationError",
@@ -130,6 +132,7 @@ __all__ = [
     "LinkupTimeoutError",
     "LinkupTooManyRequestsError",
     "LinkupUnknownError",
+    "LinkupUnsupportedTaskTypeError",
     "NoResultError",
     "PaymentRequiredError",
     "ResearchTask",
@@ -153,5 +156,6 @@ __all__ = [
     "TimeoutError",
     "TooManyRequestsError",
     "UnknownError",
+    "UnsupportedTaskTypeError",
     "__version__",
 ]

--- a/src/linkup/_client.py
+++ b/src/linkup/_client.py
@@ -25,6 +25,7 @@ from ._errors import (
     LinkupTimeoutError,
     LinkupTooManyRequestsError,
     LinkupUnknownError,
+    LinkupUnsupportedTaskTypeError,
 )
 from ._types import (
     JSONObject,
@@ -1341,6 +1342,11 @@ class LinkupClient:
                     f"Original error message: {error_msg}."
                 )
             if response.status_code == 403:
+                if code == "TASK_TYPE_NOT_SUPPORTED":
+                    raise LinkupUnsupportedTaskTypeError(
+                        "The Linkup API returned an unsupported task type error (403). \n"
+                        f"Original error message: {error_msg}."
+                    )
                 raise LinkupAuthenticationError(
                     "The Linkup API returned an authorization error (403). Make sure your API "
                     "key is valid.\n"
@@ -1692,7 +1698,9 @@ class LinkupClient:
         if task_type == "research":
             return self._parse_research_task(task_data)
 
-        raise ValueError(f"Unexpected task type value: '{task_type}'")
+        raise LinkupUnsupportedTaskTypeError(
+            f"The Linkup API returned an unsupported task type '{task_type}'."
+        )
 
     def _parse_research_tasks_page(self, response_data: dict[str, Any]) -> LinkupResearchTasksPage:
         return LinkupResearchTasksPage.model_validate(

--- a/src/linkup/_errors.py
+++ b/src/linkup/_errors.py
@@ -136,3 +136,9 @@ class LinkupUnknownError(Exception):
     """Unknown error, raised when the Linkup API returns an unknown status code."""
 
     pass
+
+
+class LinkupUnsupportedTaskTypeError(Exception):
+    """Unsupported task type error, raised when a task type is not supported by this SDK."""
+
+    pass

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -475,6 +475,19 @@ test_search_error_parameters = [
         linkup.AuthenticationError,
     ),
     (
+        403,
+        b"""
+        {
+            "error": {
+                "code": "TASK_TYPE_NOT_SUPPORTED",
+                "message": "Extract tasks are not enabled for this organization.",
+                "details": []
+            }
+        }
+        """,
+        linkup.UnsupportedTaskTypeError,
+    ),
+    (
         401,
         b"""
         {
@@ -1490,6 +1503,36 @@ def test_list_tasks(mocker: MockerFixture, client: linkup.Client) -> None:
     assert isinstance(tasks_page.data[0], linkup.ResearchTask)
     assert tasks_page.data[0].input.query == "query"
     assert tasks_page.quota.in_flight == 1
+
+
+def test_get_task_unsupported_task_type(mocker: MockerFixture, client: linkup.Client) -> None:
+    mocker.patch(
+        "httpx.Client.request",
+        return_value=Response(
+            status_code=200,
+            content=b"""
+            {
+                "createdAt": "2026-05-18T00:00:00.000Z",
+                "error": null,
+                "id": "extract-task",
+                "input": {
+                    "q": "query",
+                    "url": "https://example.com"
+                },
+                "output": null,
+                "status": "pending",
+                "type": "extract",
+                "updatedAt": "2026-05-18T00:00:00.000Z"
+            }
+            """,
+        ),
+    )
+
+    with pytest.raises(
+        linkup.UnsupportedTaskTypeError,
+        match="unsupported task type 'extract'",
+    ):
+        client.get_task("extract-task")
 
 
 def test_get_task_structured_search_output_keeps_search_results_shape_raw(


### PR DESCRIPTION
## Description

- the platform `/tasks` endpoints can now return the beta `extract` task type, while the Python SDK only supports stable `search`, `fetch`, and `research` tasks
- synchronized the SDK by turning unsupported task types into explicit `UnknownError` failures in `get_task`, and by refining `TASK_TYPE_NOT_SUPPORTED` 403 responses away from misleading authentication errors
- added focused regression tests for unsupported task payloads and 403 error refinement

## Checklist

- [x] I have installed `prek` on this project (for instance with the `make install-dev` command) **before** creating any commit, or I have run successfully the `make lint` command on my changes.
- [x] I have run successfully the `make typecheck test` command on my changes.
- [ ] I have updated the `README.md` if my changes affected it.