### PR TITLE
fix: handle fetch target unreachable errors

### DIFF
--- a/src/linkup/__init__.py
+++ b/src/linkup/__init__.py
@@ -4,6 +4,7 @@ from ._errors import (
     LinkupBudgetLimitExceededError,
     LinkupFailedFetchError,
     LinkupFetchResponseTooLargeError,
+    LinkupFetchTargetUnreachableError,
     LinkupFetchUnsupportedContentTypeError,
     LinkupFetchUrlIsFileError,
     LinkupInsufficientCreditError,
@@ -50,6 +51,7 @@ FailedFetchError = LinkupFailedFetchError
 FetchImageExtraction = LinkupFetchImageExtraction
 FetchResponse = LinkupFetchResponse
 FetchResponseTooLargeError = LinkupFetchResponseTooLargeError
+FetchTargetUnreachableError = LinkupFetchTargetUnreachableError
 FetchUnsupportedContentTypeError = LinkupFetchUnsupportedContentTypeError
 FetchTask = LinkupFetchTask
 FetchTaskInput = LinkupFetchTaskInput
@@ -89,6 +91,7 @@ __all__ = [
     "FetchImageExtraction",
     "FetchResponse",
     "FetchResponseTooLargeError",
+    "FetchTargetUnreachableError",
     "FetchTask",
     "FetchTaskInput",
     "FetchUnsupportedContentTypeError",
@@ -103,6 +106,7 @@ __all__ = [
     "LinkupFetchImageExtraction",
     "LinkupFetchResponse",
     "LinkupFetchResponseTooLargeError",
+    "LinkupFetchTargetUnreachableError",
     "LinkupFetchTask",
     "LinkupFetchTaskInput",
     "LinkupFetchUnsupportedContentTypeError",

--- a/src/linkup/_client.py
+++ b/src/linkup/_client.py
@@ -14,6 +14,7 @@ from ._errors import (
     LinkupBudgetLimitExceededError,
     LinkupFailedFetchError,
     LinkupFetchResponseTooLargeError,
+    LinkupFetchTargetUnreachableError,
     LinkupFetchUnsupportedContentTypeError,
     LinkupFetchUrlIsFileError,
     LinkupInsufficientCreditError,
@@ -1023,6 +1024,7 @@ class LinkupClient:
             LinkupInvalidRequestError: If the provided URL is not valid.
             LinkupFailedFetchError: If the provided URL is not found or can't be fetched.
             LinkupFetchResponseTooLargeError: If the fetch response is too large.
+            LinkupFetchTargetUnreachableError: If the target URL cannot be reached.
             LinkupFetchUnsupportedContentTypeError: If the URL resolves to an unsupported content
                 type.
             LinkupTimeoutError: If the request times out.
@@ -1073,6 +1075,7 @@ class LinkupClient:
             LinkupInvalidRequestError: If the provided URL is not valid.
             LinkupFailedFetchError: If the provided URL is not found or can't be fetched.
             LinkupFetchResponseTooLargeError: If the fetch response is too large.
+            LinkupFetchTargetUnreachableError: If the target URL cannot be reached.
             LinkupFetchUnsupportedContentTypeError: If the URL resolves to an unsupported content
                 type.
             LinkupTimeoutError: If the request times out.
@@ -1314,6 +1317,12 @@ class LinkupClient:
                     raise LinkupFetchResponseTooLargeError(
                         "The Linkup API returned a fetch response too large error (400). "
                         "The provided URL's response is too large to be processed.\n"
+                        f"Original error message: {error_msg}."
+                    )
+                if code == "FETCH_TARGET_UNREACHABLE":
+                    raise LinkupFetchTargetUnreachableError(
+                        "The Linkup API returned a fetch target unreachable error (400). "
+                        "The provided URL could not be reached by Linkup.\n"
                         f"Original error message: {error_msg}."
                     )
                 if code == "FETCH_UNSUPPORTED_CONTENT_TYPE":

--- a/src/linkup/_errors.py
+++ b/src/linkup/_errors.py
@@ -76,6 +76,16 @@ class LinkupFetchResponseTooLargeError(Exception):
     pass
 
 
+class LinkupFetchTargetUnreachableError(Exception):
+    """Fetch target unreachable error, raised when the Linkup API returns a 400 status code.
+
+    It is returned when the Linkup API cannot connect to the requested target URL, such as when
+    the host is unreachable or the request times out before a response is received.
+    """
+
+    pass
+
+
 class LinkupFetchUnsupportedContentTypeError(Exception):
     """Unsupported fetch content type error, raised when the Linkup API returns a 400 status code.
 

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -1048,6 +1048,19 @@ test_fetch_error_parameters = [
         b"""
         {
             "error": {
+                "code": "FETCH_TARGET_UNREACHABLE",
+                "message": "The target URL could not be reached (connection failed or timed out)",
+                "details": []
+            }
+        }
+        """,
+        linkup.FetchTargetUnreachableError,
+    ),
+    (
+        400,
+        b"""
+        {
+            "error": {
                 "code": "FETCH_UNSUPPORTED_CONTENT_TYPE",
                 "message": "The URL returned an unsupported content type",
                 "details": []


### PR DESCRIPTION
## Description

The public `/v1/fetch` API surface now reports a dedicated `FETCH_TARGET_UNREACHABLE` 400 error code when Linkup cannot reach the target URL.

This PR synchronizes the Python SDK by:
- adding `LinkupFetchTargetUnreachableError` and its public alias export,
- mapping `FETCH_TARGET_UNREACHABLE` to that error in the client,
- documenting the raised exception in the fetch client docstrings,
- covering the new contract in the fetch error tests.

## Checklist

- [x] I have installed `prek` on this project (for instance with the `make install-dev` command) **before** creating any commit, or I have run successfully the `make lint` command on my changes.
- [x] I have run successfully the `make typecheck test` command on my changes.
- [ ] I have updated the `README.md` if my changes affected it.