### PR TITLE
feat: support flash search depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ pip install linkup-sdk[x402]
 
 #### 📝 Search
 
-The `search` function can be used to performs web searches. It supports three different complexity
+The `search` function can be used to performs web searches. It supports four different complexity
 modes, through the `depth` parameter:
 
-- `"fast"` (**beta**), for sub-second responses to simple, focused queries (must be keyword-based)
-- `"standard"`, for single-iteration agentic search that can interpret the query, run parallel
-  sub-searches, and scrape one URL while remaining fast
-- `"deep"`, for slower, more agentic and complex responses, suited to more complex queries (e.g.
-  "What is the company profile of LangChain accross the last few years, and how does it compare to
-  its concurrents?")
+- `"flash"` is lowest latency: ranked sources and snippets in a few hundred milliseconds, built for
+  low-latency use cases,
+- `"fast"` is higher-quality one-shot retrieval in about a second — the recommended default for
+  most agentic applications,
+- `"standard"` is a single pass of agentic search for queries that span several topics or sources,
+- `"deep"` runs several search iterations, optimizing for coverage and multi-hop agentic workflows
 
 The `search` function also supports three output types, through the `output_type` parameter:
 
@@ -103,7 +103,7 @@ import linkup
 client = linkup.Client()  # API key can be read from the environment variable or passed as an argument
 search_response: linkup.SourcedAnswer = client.search(
     query="What are the 3 major events in the life of Abraham Lincoln?",
-    depth="deep",  # "fast" (beta), "standard", or "deep"
+    depth="deep",  # "flash", "fast", "standard", or "deep"
     output_type="sourcedAnswer",  # "searchResults" or "sourcedAnswer" or "structured"
     structured_output_schema=None,  # must be filled if output_type is "structured"
 )
@@ -231,7 +231,7 @@ async def main() -> None:
     client = linkup.Client()  # API key can be read from the environment variable or passed as an argument
     search_response: linkup.SourcedAnswer = await client.async_search(
         query="What are the 3 major events in the life of Abraham Lincoln?",
-        depth="deep",  # "fast" (beta), "standard", or "deep"
+        depth="deep",  # "flash", "fast", "standard", or "deep"
         output_type="sourcedAnswer",  # "searchResults" or "sourcedAnswer" or "structured"
         structured_output_schema=None,  # must be filled if output_type is "structured"
     )

--- a/src/linkup/_client.py
+++ b/src/linkup/_client.py
@@ -107,7 +107,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults"],
         structured_output_schema: None = None,
         include_images: bool | None = None,
@@ -126,7 +126,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["sourcedAnswer"],
         structured_output_schema: None = None,
         include_images: bool | None = None,
@@ -145,7 +145,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str,
         include_images: bool | None = None,
@@ -164,7 +164,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str,
         include_images: bool | None = None,
@@ -183,7 +183,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults", "sourcedAnswer", "structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str | None = None,
         include_images: bool | None = None,
@@ -203,7 +203,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults", "sourcedAnswer", "structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str | None = None,
         include_images: bool | None = None,
@@ -224,10 +224,12 @@ class LinkupClient:
 
         Args:
             query: The search query.
-            depth: The depth of the search. Can be "fast" (beta), for a sub-second search (query
-                must be keyword-based), "standard", for a simple, straightforward search (query can
-                be free text), or "deep" for a more powerful agentic workflow (query can be free
-                text).
+            depth: The depth of the search. "flash" is lowest latency: ranked sources and snippets
+                in a few hundred milliseconds, built for low-latency use cases. "fast" is
+                higher-quality one-shot retrieval in about a second — the recommended default for
+                most agentic applications. "standard" is a single pass of agentic search for queries
+                that span several topics or sources. "deep" runs several search iterations,
+                optimizing for coverage and multi-hop agentic workflows.
             output_type: The type of output which is expected: "searchResults" will output raw
                 search results, "sourcedAnswer" will output the answer to the query and sources
                 supporting it, and "structured" will base the output on the format provided in
@@ -304,7 +306,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults"],
         structured_output_schema: None = None,
         include_images: bool | None = None,
@@ -323,7 +325,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["sourcedAnswer"],
         structured_output_schema: None = None,
         include_images: bool | None = None,
@@ -342,7 +344,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str,
         include_images: bool | None = None,
@@ -361,7 +363,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str,
         include_images: bool | None = None,
@@ -380,7 +382,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults", "sourcedAnswer", "structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str | None = None,
         include_images: bool | None = None,
@@ -400,7 +402,7 @@ class LinkupClient:
         self,
         query: str,
         *,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults", "sourcedAnswer", "structured"],
         structured_output_schema: type[pydantic.BaseModel] | dict[str, Any] | str | None = None,
         include_images: bool | None = None,
@@ -421,10 +423,12 @@ class LinkupClient:
 
         Args:
             query: The search query.
-            depth: The depth of the search. Can be "fast" (beta), for a sub-second search (query
-                must be keyword-based), "standard", for a simple, straightforward search (query can
-                be free text), or "deep" for a more powerful agentic workflow (query can be free
-                text).
+            depth: The depth of the search. "flash" is lowest latency: ranked sources and snippets
+                in a few hundred milliseconds, built for low-latency use cases. "fast" is
+                higher-quality one-shot retrieval in about a second — the recommended default for
+                most agentic applications. "standard" is a single pass of agentic search for queries
+                that span several topics or sources. "deep" runs several search iterations,
+                optimizing for coverage and multi-hop agentic workflows.
             output_type: The type of output which is expected: "searchResults" will output raw
                 search results, "sourcedAnswer" will output the answer to the query and sources
                 supporting it, and "structured" will base the output on the format provided in
@@ -1460,7 +1464,7 @@ class LinkupClient:
     def _get_search_params(
         self,
         query: str,
-        depth: Literal["fast", "standard", "deep"],
+        depth: Literal["flash", "fast", "standard", "deep"],
         output_type: Literal["searchResults", "sourcedAnswer", "structured"],
         structured_output_schema: type[pydantic.BaseModel] | str | dict[str, Any] | None,
         include_images: bool | None,

--- a/src/linkup/_types.py
+++ b/src/linkup/_types.py
@@ -136,7 +136,7 @@ class LinkupSearchTaskInput(_LinkupBaseModel):
 
     Attributes:
         query: The search query.
-        depth: The search depth. "fast" depth is in beta and only works with keyword-based queries.
+        depth: The search depth.
         output_type: The expected search output type.
         include_images: Whether image results should be included.
         from_date: The start date used to filter search sources, if any.
@@ -150,7 +150,7 @@ class LinkupSearchTaskInput(_LinkupBaseModel):
     """
 
     query: str = pydantic.Field(validation_alias="q")
-    depth: Literal["fast", "standard", "deep"]
+    depth: Literal["flash", "fast", "standard", "deep"]
     output_type: Literal["searchResults", "sourcedAnswer", "structured"] = pydantic.Field(
         validation_alias="outputType"
     )

--- a/tests/unit/client_test.py
+++ b/tests/unit/client_test.py
@@ -21,8 +21,8 @@ class Company(pydantic.BaseModel):
 
 test_search_parameters = [
     (
-        {"query": "query", "depth": "standard", "output_type": "searchResults"},
-        {"q": "query", "depth": "standard", "outputType": "searchResults"},
+        {"query": "query", "depth": "flash", "output_type": "searchResults"},
+        {"q": "query", "depth": "flash", "outputType": "searchResults"},
         b"""
         {
             "results": [
@@ -1276,7 +1276,7 @@ def test_create_tasks(mocker: MockerFixture, client: linkup.Client) -> None:
         [
             linkup.SearchTaskInput(
                 query="query",
-                depth="deep",
+                depth="flash",
                 output_type="structured",
                 structured_output_schema=Company,
             ),
@@ -1299,7 +1299,7 @@ def test_create_tasks(mocker: MockerFixture, client: linkup.Client) -> None:
                 "type": "search",
                 "input": {
                     "q": "query",
-                    "depth": "deep",
+                    "depth": "flash",
                     "outputType": "structured",
                     "structuredOutputSchema": json.dumps(Company.model_json_schema()),
                 },


### PR DESCRIPTION
## Description

The public `/search` contract now exposes `flash` as a stable search depth, while the Python SDK annotations, task model, and documentation omitted it and still described `fast` as beta.

- add `flash` to sync and async client type signatures and search task validation
- update search-depth docstrings and README documentation for all four stable modes
- cover `flash` in direct search and task request shaping tests

## Validation

- `make lint typecheck test` (108 tests passed)

## Checklist

- [x] I have installed `prek` on this project (for instance with the `make install-dev` command) **before** creating any commit, or I have run successfully the `make lint` command on my changes.
- [x] I have run successfully the `make typecheck test` command on my changes.
- [x] I have updated the `README.md` if my changes affected it.